### PR TITLE
Fail if stylelint isn't available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,17 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         working_directory: ./test
+
+    # This is expected to fail.
+    - name: Test missing stylelint
+      id: missing
+      uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        working_directory: ./
+      continue-on-error: true
+
+    # Fail if the previous step didn't.
+    - name: Check failure
+      if: steps.missing.outcome != 'failure'
+      run: exit 1

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,17 @@ runs:
       with:
         reviewdog_version: latest
 
+    # reviewdog/action-stylelint doesn't actually fail if stylelint
+    # isn't installed, so we check for it explicitly here.
+    - name: Ensure Stylelint is available
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        # Simply try to run it, if it's not there, the shell will
+        # error. It also catches some other possible problems
+        # preventing stylelint from working.
+        $(npm bin)/stylelint -v
+
     - name: Stylelint
       uses: reviewdog/action-stylelint@v1
       with:


### PR DESCRIPTION
Currently the action doesn't fail if stylelint isn't installed, which makes it look like the style is top notch.

Fix it by trying to invoke stylelint.